### PR TITLE
Fix Crash on Related Items Enqueue Popup

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
@@ -181,6 +181,9 @@ public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, Related
     protected void showInfoItemDialog(final StreamInfoItem item) {
         try {
             final Fragment parentFragment = getParentFragment();
+
+            // Try and attach the InfoItemDialog to the parent fragment of the RelatedItemsFragment
+            // so that its context is not lost when the RelatedItemsFragment is reinitialized.
             if (parentFragment != null) {
                 new InfoItemDialog.Builder(
                         parentFragment.getActivity(),

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
@@ -18,8 +19,10 @@ import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
+import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.ktx.ViewUtils;
 
 import java.io.Serializable;
@@ -173,4 +176,30 @@ public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, Related
         }
         return mode;
     }
+
+    @Override
+    protected void showInfoItemDialog(final StreamInfoItem item) {
+        try {
+            final Fragment parentFragment = getParentFragment();
+            if (parentFragment != null) {
+                new InfoItemDialog.Builder(
+                        parentFragment.getActivity(),
+                        parentFragment.getContext(),
+                        parentFragment,
+                        item
+                ).create().show();
+            } else {
+                new InfoItemDialog.Builder(
+                        getActivity(),
+                        getContext(),
+                        this,
+                        item)
+                        .create().show();
+            }
+
+        } catch (final IllegalArgumentException e) {
+            InfoItemDialog.Builder.reportErrorDuringInitialization(e, item);
+        }
+    }
+
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Changes the `InfoItemDialog` popup modal for the `RelatedItemsFragment` to be attached to the parent context of the `RelatedItemsFragment`. This prevents the popup not being attached a context when the player automatically changes to the next video and the `RelatedItemsFragment` is re-initialized.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
